### PR TITLE
Move Dragonflight Folder so Module is Discoverable

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -5,6 +5,7 @@ move-folders:
     LazyCurve/modules/BFA: LazyCurve_BFA
     LazyCurve/modules/Shadowlands: LazyCurve_Shadowlands
     LazyCurve/modules/Tazavesh: LazyCurve_Tazavesh
+    LazyCurve/modules/Dragonflight: LazyCurve_Dragonflight
 
 externals:
     libs/LibStub:


### PR DESCRIPTION
Noticed this as an issue and fixed it locally but this is preventing Dragonflight related stuffs from working for me